### PR TITLE
Resolves #23

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,12 @@
-all:
+all: build
+
+build: test
+	@echo "Building..."
 	mkdir -p dist
 	gox -ldflags="-s -w -X main.version=$(shell git describe --tags)" -tags="full" -osarch="darwin/amd64 linux/386 linux/amd64 linux/arm freebsd/amd64 windows/amd64" -output="dist/jiq_{{.OS}}_{{.Arch}}" github.com/fiatjaf/jiq/cmd/jiq
+	@echo
+
+test:
+	@echo "Running tests..."
+	go test ./...
+	@echo

--- a/cmd/jiq/jiq_test.go
+++ b/cmd/jiq/jiq_test.go
@@ -1,52 +1,42 @@
 package main
 
 import (
-	"fmt"
-	"os"
 	"testing"
 
-	"github.com/fiatjaf/jiq"
 	"github.com/stretchr/testify/assert"
 )
 
-var called int = 0
+const (
+	Failure = 2
+	Success = 0
+)
 
-func TestMain(m *testing.M) {
-	called = 0
-	code := m.Run()
-	defer os.Exit(code)
+type mockRunner struct {
+	returnSuccess bool
 }
 
-func TestjiqRun(t *testing.T) {
-	var assert = assert.New(t)
-
-	e := &jiq.Engine{}
-	result := run(e, false)
-	assert.Zero(result)
-	assert.Equal(2, called)
-
-	result = run(e, true)
-	assert.Equal(1, called)
-
-	result = run(e, false)
-	assert.Zero(result)
-}
-
-func TestjiqRunWithError(t *testing.T) {
-	called = 0
-	var assert = assert.New(t)
-	e := &jiq.Engine{}
-	result := run(e, false)
-	assert.Equal(2, result)
-	assert.Equal(0, called)
-}
-
-type EngineMock struct{ err error }
-
-func (e *EngineMock) Run() *jiq.EngineResult {
-	return &jiq.EngineResult{
-		Err:     fmt.Errorf(""),
-		Qs:      ".querystring",
-		Content: `{"test": "result"}`,
+func (r mockRunner) run() int {
+	if r.returnSuccess {
+		return Success
+	} else {
+		return Failure
 	}
+}
+
+// TODO: Test parsing args by breaking it out of main
+// Until then, just run the mock
+func TestJiqRun(t *testing.T) {
+	var assert = assert.New(t)
+
+	m := mockRunner{returnSuccess: true}
+	result := doRun(m)
+	assert.Equal(Success, result)
+}
+
+func TestJiqRunWithError(t *testing.T) {
+	var assert = assert.New(t)
+
+	m := mockRunner{returnSuccess: false}
+	result := doRun(m)
+	assert.Equal(Failure, result)
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/mattn/go-runewidth v0.0.9 // indirect
+	github.com/mitchellh/gox v1.0.1 // indirect
 	github.com/nsf/termbox-go v0.0.0-20200418040025-38ba6e5628f1
 	github.com/stretchr/testify v1.6.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,13 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/hashicorp/go-version v1.0.0 h1:21MVWPKDphxa7ineQQTrCU5brh7OuVVAzGOCnnCPtE8=
+github.com/hashicorp/go-version v1.0.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/mitchellh/gox v1.0.1 h1:x0jD3dcHk9a9xPSDN6YEL4xL6Qz0dvNYm8yZqui5chI=
+github.com/mitchellh/gox v1.0.1/go.mod h1:ED6BioOGXMswlXa2zxfh/xdd5QhwYliBFn9V18Ap4z4=
+github.com/mitchellh/iochan v1.0.0 h1:C+X3KsSTLFVBr/tK1eYN/vs4rJcvsiLU338UhYPJWeY=
+github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/nsf/termbox-go v0.0.0-20200418040025-38ba6e5628f1 h1:lh3PyZvY+B9nFliSGTn5uFuqQQJGuNrD0MLCokv09ag=
 github.com/nsf/termbox-go v0.0.0-20200418040025-38ba6e5628f1/go.mod h1:IuKpRQcYE1Tfu+oAQqaLisqDeXgjyyltCfsaoYN18NQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
- Adds a "both" option to print both results and query
- Added --version to help text
- Added running tests to Makefile
- Started work on testing command parsing by mocking run function by implementing interface
- Added new lines to other display options

Can break this up into separate commits if necessary. Also, not sure how others use `jiq` so if the lack of new lines are intentional (perhaps being stored as a variable?) I can remove that and add later as an optional flag (I'm thinking of trying cobra to parse args?)