### PR TITLE
 slice bounds out of range bug fix

### DIFF
--- a/query.go
+++ b/query.go
@@ -55,6 +55,9 @@ func (q *Query) Delete(i int) []rune {
 			qq = qq[0:0]
 		}
 	} else if i == 0 {
+		if len(qq) == 0 {
+			return q.Set(qq)
+		}
 		qq = qq[1:]
 	} else if i > 0 && i < lastIdx {
 		qq = append(qq[:i], qq[i+1:]...)

--- a/query_test.go
+++ b/query_test.go
@@ -69,6 +69,10 @@ func TestQueryDelete(t *testing.T) {
 	assert.Equal([]rune("llo.world"), q.Delete(0))
 	assert.Equal([]rune("ll.world"), q.Delete(2))
 	assert.Equal([]rune("llworld"), q.Delete(2))
+
+	q = NewQuery([]rune(""))
+	assert.Equal([]rune(""), q.Delete(0))
+
 }
 
 func TestGetKeywords(t *testing.T) {


### PR DESCRIPTION
when the cursor is on the 0 index and the user keeps on deleting the characters on the right until there are no more characters left,  slice bounds out of range occurs.

This PR fixes the issue.